### PR TITLE
ramips: fix HiWiFi HC5962 image booting

### DIFF
--- a/target/linux/ramips/dts/HC5962.dts
+++ b/target/linux/ramips/dts/HC5962.dts
@@ -69,12 +69,12 @@
 
 	partition@140000 {
 		label = "kernel";
-		reg = <0x140000 0x200000>;
+		reg = <0x140000 0x400000>;
 	};
 
-	partition@340000 {
+	partition@540000 {
 		label = "ubi";
-		reg = <0x340000 0x1E00000>;
+		reg = <0x540000 0x1C00000>;
 	};
 
 	partition@2140000 {

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -42,6 +42,12 @@ define Device/Default
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
 endef
 
+define Device/uimage-lzma-loader
+  LOADER_TYPE := bin
+  KERNEL/lzma-loader := $(KERNEL_DTB) | loader-kernel
+  KERNEL := $$(KERNEL/lzma-loader) | uImage none
+endef
+
 define Build/patch-dtb
 	$(call Image/BuildDTB,../dts/$(DTS).dts,$@.dtb)
 	$(STAGING_DIR_HOST)/bin/patch-dtb $@ $@.dtb
@@ -62,6 +68,22 @@ define Build/relocate-kernel
 		cat $@ \
 	) > $@.new
 	mv $@.new $@
+endef
+
+define Build/loader-common
+	rm -rf $@.src
+	$(MAKE) -C lzma-loader \
+		PKG_BUILD_DIR="$@.src" \
+		TARGET_DIR="$(dir $@)" LOADER_NAME="$(notdir $@)" \
+		BOARD="$(BOARDNAME)" PLATFORM="ralink" \
+		LZMA_TEXT_START=0x80a00000 LOADADDR=$(KERNEL_LOADADDR) \
+		$(1) compile loader.$(LOADER_TYPE)
+	mv "$@.$(LOADER_TYPE)" "$@"
+	rm -rf $@.src
+endef
+
+define Build/loader-kernel
+	$(call Build/loader-common,LOADER_DATA="$@")
 endef
 
 define MkCombineduImage

--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -75,7 +75,7 @@ define Build/loader-common
 	$(MAKE) -C lzma-loader \
 		PKG_BUILD_DIR="$@.src" \
 		TARGET_DIR="$(dir $@)" LOADER_NAME="$(notdir $@)" \
-		BOARD="$(BOARDNAME)" PLATFORM="ralink" \
+		BOARD="$(DEVICE_NAME)" PLATFORM="ralink" \
 		LZMA_TEXT_START=0x80a00000 LOADADDR=$(KERNEL_LOADADDR) \
 		$(1) compile loader.$(LOADER_TYPE)
 	mv "$@.$(LOADER_TYPE)" "$@"

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -123,10 +123,11 @@ endef
 TARGET_DEVICES += firewrt
 
 define Device/hc5962
+  $(Device/uimage-lzma-loader)
   DTS := HC5962
   BLOCKSIZE := 128k
   PAGESIZE := 2048
-  KERNEL_SIZE := 2097152
+  KERNEL_SIZE := 4096k
   UBINIZE_OPTS := -E 5
   IMAGE_SIZE := $(ralink_default_fw_size_32M)
   IMAGES += factory.bin


### PR DESCRIPTION
### Motivation
- The HC5962 images generated by the earlier device add are not recognized/booted by the stock bootloader because the bootloader cannot handle the LZMA-compressed kernel directly and the kernel slot was too small for newer kernels.
- Provide a safe image format that lets the bootloader load a small uncompressed loader which then decompresses the kernel, and adjust partitions to match the image layout.

### Description
- Add a `Device/uimage-lzma-loader` profile and `loader-kernel` build steps in `target/linux/ramips/image/Makefile` so images include a small uncompressed LZMA loader that loads the compressed kernel. 
- Implement `Build/loader-common` and `Build/loader-kernel` targets to build the LZMA loader using the existing `lzma-loader` recipe. 
- Switch the HC5962 device entry in `target/linux/ramips/image/mt7621.mk` to use the new `uimage-lzma-loader` profile and increase `KERNEL_SIZE` from 2 MiB to 4 MiB. 
- Update `target/linux/ramips/dts/HC5962.dts` to enlarge the `kernel` partition to `0x400000` and move the `ubi` partition start to `0x540000` so on-flash layout matches the new image layout.

### Testing
- Ran `git diff --check` which reported no whitespace/patch problems and the changes were committed successfully. (success)
- Attempted dry-run build `make -n target/linux/compile V=s` but the prereq/config stage failed due to a missing host utility `file` in the build environment, so the full build could not be exercised. (blocked)
- Attempted `make -n target/linux/compile V=s FORCE=1` which also encountered the same host-tool prereq failure and could not complete image generation. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2035bc1108832bbe35dccdbb9aef31)